### PR TITLE
issue #12 Fix KeyError: cups

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -59,7 +59,7 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
     # Declare eds helper
     helper = EdsHelper(config[CONF_USERNAME], config[CONF_PASSWORD])
     cups = None
-    if config[CONF_CUPS]:
+    if CONF_CUPS in config:
         cups = config[CONF_CUPS]
     entities.append(EdsSensor(helper, cups=cups))
     for sensor in config[CONF_EXPLODE_SENSORS]:


### PR DESCRIPTION
This fixes the issue #12 

Error while setting up edistribucion platform for sensor
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 250, in _async_setup_platform
    await asyncio.shield(task)
  File "/config/custom_components/edistribucion/sensor.py", line 62, in async_setup_platform
    if config[CONF_CUPS]:
KeyError: 'cups'